### PR TITLE
fix: prevent duplicate workflow runs and rename workflows

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,7 +1,9 @@
-name: HACS Validate
+name: ✅ HACS Validation
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,15 +1,17 @@
-name: Hassfest
+name: 🏠 Home Assistant Validation
 
 on:
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 0 * * *"
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    pull_request:
+    schedule:
+        - cron: "0 0 * * *"
+    workflow_dispatch:
 
 jobs:
-  validate:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "actions/checkout@v4"
-      - uses: home-assistant/actions/hassfest@master
+    validate:
+        runs-on: "ubuntu-latest"
+        steps:
+            - uses: "actions/checkout@v4"
+            - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,7 +1,9 @@
-name: CI
+name: 🔍 Code Quality
 
 on:
     push:
+        branches:
+            - main
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,32 +1,32 @@
-name: Release
+name: 📦 Release
 
 on:
-  release:
-    types: [published]
+    release:
+        types: [published]
 
 permissions:
-  contents: write
+    contents: write
 
 jobs:
-  release:
-    name: Prepare release assets
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    release:
+        name: Prepare release assets
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Get version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            - name: Get version from tag
+              id: version
+              run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Create release asset
-        run: |
-          cd custom_components
-          zip -r ../cez_hdo.zip cez_hdo -x "*.pyc" -x "*__pycache__*" -x "*.DS_Store"
+            - name: Create release asset
+              run: |
+                  cd custom_components
+                  zip -r ../cez_hdo.zip cez_hdo -x "*.pyc" -x "*__pycache__*" -x "*.DS_Store"
 
-      - name: Upload release asset
-        uses: softprops/action-gh-release@v2
-        with:
-          files: cez_hdo.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Upload release asset
+              uses: softprops/action-gh-release@v2
+              with:
+                  files: cez_hdo.zip
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -1,4 +1,4 @@
-name: Traffic Stats
+name: 📊 Traffic Stats
 
 on:
   schedule:


### PR DESCRIPTION
## Changes

- Restrict `push` trigger to `main` branch only (prevents duplicate runs on PRs)
- Rename workflow files for clarity:
  - `ci.yaml` → `quality.yaml`
  - `validate.yaml` → `hacs.yaml`
  - `traffic-stats.yaml` → `stats.yaml`
- Add descriptive workflow names with emojis:
  - 🔍 Code Quality
  - ✅ HACS Validation
  - 🏠 Home Assistant Validation
  - 📦 Release
  - 📊 Traffic Stats
- Add `uv` installation step for pre-commit hook

Closes #50