### PR TITLE
fix: resolve LovelaceData mode attribute error in HA 2026.02+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,6 @@ test2.py
 *local*
 *package-lock.json
 *package.json
-RELEASE_NOTES_*.md
 __*
 !__init__.py
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,20 @@
 
 ---
 
+## v3.1.1 (2026-02-05)
+
+### 🐛 Opravy
+
+#### Kompatibilita s Home Assistant 2026.02+
+
+- **Opravena chyba** `'LovelaceData' object has no attribute 'mode'`
+- V HA 2026.02+ byla změněna struktura `LovelaceData` – objekt již nemá atribut `mode`
+- Nová detekce storage režimu pomocí kontroly typu resources kolekce
+
+**Fixes:** [#62](https://github.com/Cmajda/ha_cez_distribuce/issues/62)
+
+---
+
 ## v3.1.0 (2026-02-04)
 
 ### 🚀 Hlavní změny

--- a/RELEASE_NOTES_EN.md
+++ b/RELEASE_NOTES_EN.md
@@ -1,0 +1,121 @@
+# Release Notes – ČEZ HDO
+
+---
+
+## v3.1.1 (2026-02-05)
+
+### 🐛 Fixes
+
+#### Compatibility with Home Assistant 2026.02+
+
+- **Fixed error** `'LovelaceData' object has no attribute 'mode'`
+- In HA 2026.02+, the `LovelaceData` structure was changed – the object no longer has a `mode` attribute
+- New storage mode detection using resources collection type check
+
+**Fixes:** [#62](https://github.com/Cmajda/ha_cez_distribuce/issues/62)
+
+---
+
+## v3.1.0 (2026-02-04)
+
+### 🚀 Main Changes
+
+Version 3.1.0 brings **CAPTCHA verification support** and new sensors for tracking data validity.
+
+#### CAPTCHA API Protection
+
+- ČEZ Distribuce introduced CAPTCHA protection on their API
+- **New configuration step** – displays CAPTCHA image and user enters the code
+- Data is fetched once and stored in cache
+- **Data validity 6 days** – reconfiguration required after expiry
+
+#### New Entities for Data Validity Tracking
+
+| Type   | Entity                        | Description            |
+| ------ | ----------------------------- | ---------------------- |
+| Binary | `cez_hdo_data_valid_*`        | Data is valid (on/off) |
+| Sensor | `cez_hdo_data_valid_until_*`  | Expiry date            |
+| Sensor | `cez_hdo_data_age_days_*`     | Data age in days       |
+| Sensor | `cez_hdo_days_until_expiry_*` | Days until expiry      |
+
+#### Automatic Notifications
+
+- **Day 5:** Persistent notification with warning
+- **Day 6:** Persistent notification about data expiry
+
+### ✨ Improvements
+
+- Better error handling for CAPTCHA validation
+- Options Flow also supports CAPTCHA for data refresh
+- Updated documentation with automation examples
+
+### 📚 Documentation
+
+- Added "Data Validity and Refresh" section to user-guide
+- Updated known-issues with resolved CAPTCHA issue info
+- Added automation examples for expiry notifications
+
+---
+
+## v3.0.1 (2026-02-03)
+
+### 📚 Documentation
+
+- Added CAPTCHA issue notice to README
+
+---
+
+## v3.0.0 (2026-02-02)
+
+### 🚀 Main Changes
+
+Version 3.0.0 brings a **complete redesign** of the integration
+with focus on modern Home Assistant architecture.
+
+#### Config Flow – GUI Configuration
+
+- **No YAML** – integration is configured via Settings → Devices & Services
+- **4-step wizard:**
+  1. Enter EAN
+  2. Select signal
+  3. Entity suffix (user-configurable)
+  4. Set NT/VT prices
+- **Options Flow** – change settings anytime after installation
+- **Multiple signals per EAN** – same EAN can be added multiple times with different signals
+
+#### Device Registry
+
+- All entities are grouped under a **hub** (last 6 digits of EAN)
+- Each signal creates its own **device** with signal code
+- Better overview in Home Assistant UI
+
+#### New Data Storage
+
+- Data moved from `www/cez_hdo/` to `custom_components/cez_hdo/data/`
+- Migration happens automatically on first run
+- Old data remains as backup (can be deleted manually)
+
+#### Lovelace Card
+
+- Automatic registration in Lovelace resources
+- Visual editor with all options
+- Display of tariff states, times, remaining time, current price
+- 7-day HDO schedule
+
+### ⚠️ Breaking Changes
+
+- **YAML configuration removed** – delete from `configuration.yaml`
+- **Entity IDs changed** – old automations need updates
+- **Folder structure changed** – `www/cez_hdo/` no longer used
+
+### 📚 Documentation
+
+- Complete user-guide rewrite
+- Added upgrade-guide for migration from v2.x
+- Added developer-guide
+
+---
+
+## Migration from v2.x
+
+See [Upgrade Guide](docs/en/upgrade-guide.md) for detailed migration instructions.

--- a/custom_components/cez_hdo/frontend/__init__.py
+++ b/custom_components/cez_hdo/frontend/__init__.py
@@ -40,7 +40,9 @@ class CezHdoCardRegistration:
         """Check if Lovelace is running in storage mode.
 
         In HA 2026.02+, LovelaceData no longer has a 'mode' attribute.
-        We detect storage mode by checking if resources is a ResourceStorageCollection.
+        We detect storage mode by checking whether the resources collection
+        exposes the ``async_create_item`` method, which is present for
+        storage-backed resources and absent for YAML-based resources.
         """
         resources = self.lovelace_resources
         # ResourceStorageCollection has async_create_item method, ResourceYAMLCollection does not

--- a/custom_components/cez_hdo/manifest.json
+++ b/custom_components/cez_hdo/manifest.json
@@ -9,7 +9,6 @@
                 "@cmajda"
         ],
         "config_flow": true,
-        "homeassistant": "2024.7.0",
         "dependencies": [],
         "documentation": "https://github.com/Cmajda/ha_cez_distribuce/blob/main/docs/cs/user-guide.md",
         "iot_class": "cloud_polling",

--- a/custom_components/cez_hdo/manifest.json
+++ b/custom_components/cez_hdo/manifest.json
@@ -9,8 +9,9 @@
                 "@cmajda"
         ],
         "config_flow": true,
+        "homeassistant": "2024.7.0",
         "dependencies": [],
-        "documentation": "https://github.com/Cmajda/ha_cez_distribuce/blob/main/docs/en/user-guide.md",
+        "documentation": "https://github.com/Cmajda/ha_cez_distribuce/blob/main/docs/cs/user-guide.md",
         "iot_class": "cloud_polling",
         "issue_tracker": "https://github.com/Cmajda/ha_cez_distribuce/issues",
         "quality_scale": "silver",
@@ -19,5 +20,5 @@
                 "lxml",
                 "packaging"
         ],
-        "version": "3.1.0"
+        "version": "3.1.1"
 }

--- a/docs/cs/known-issues.md
+++ b/docs/cs/known-issues.md
@@ -4,9 +4,34 @@ Tento soubor obsahuje seznam známých problémů a jejich stav řešení.
 
 ---
 
-## Aktuální problémy (v3.1.0)
+## Aktuální problémy (v3.1.1)
 
-### 1. CAPTCHA ochrana API ČEZ Distribuce
+### 1. HDO rozvrh nezobrazuje správně poslední dny
+
+**Stav:** ⚠️ Známé omezení (CAPTCHA)
+
+**Popis:** Po 1 dnu od konfigurace může HDO rozvrh zobrazovat poslední dny
+jako vysoký tarif (VT). To je způsobeno omezením API ČEZ – kvůli CAPTCHA nelze
+data automaticky aktualizovat denně.
+
+**Dočasné řešení:** Překonfigurujte integraci (Nastavení → Zařízení a služby → ČEZ HDO →
+Konfigurovat), opište nový CAPTCHA kód. Data se načtou aktuální
+
+### 2. Kompatibilita s Home Assistant 2026.02+ (v3.1.0)
+
+**Stav:** ✅ Vyřešeno v v3.1.1
+
+**Popis:** V Home Assistant 2026.02+ byla změněna struktura `LovelaceData`.
+Objekt již nemá atribut `mode`, což způsobovalo chybu při spuštění integrace:
+`'LovelaceData' object has no attribute 'mode'`
+
+**Řešení:** Nová detekce storage režimu pomocí kontroly typu resources kolekce.
+
+**Sledování:** [#62](https://github.com/Cmajda/ha_cez_distribuce/issues/62)
+
+---
+
+### 3. CAPTCHA ochrana API ČEZ Distribuce
 
 **Stav:** ✅ Vyřešeno v v3.1.0
 
@@ -23,7 +48,7 @@ a vytvářet automatizace pro upozornění.
 
 ---
 
-### 2. Služba set_prices nerozeznává zařízení
+### 4. Služba set_prices nerozeznává zařízení
 
 **Stav:** ⚠️ Známé omezení
 
@@ -164,4 +189,4 @@ způsobovat problémy v některých systémech.
 
 1. Zkontrolujte, zda problém již není v tomto seznamu
 2. Vytvořte [GitHub Issue](https://github.com/Cmajda/ha_cez_distribuce/issues)
-3. Přiložte diagnostiku (Settings → Devices → ČEZ HDO → ⋮ → Download diagnostics)
+3. Přiložte diagnostiku (Nastavení → Zařízení → ČEZ HDO → ⋮ → Stáhnout diagnostiku)

--- a/docs/en/known-issues.md
+++ b/docs/en/known-issues.md
@@ -4,9 +4,34 @@ This file contains a list of known issues and their resolution status.
 
 ---
 
-## Current Issues (v3.1.0)
+## Current Issues (v3.1.1)
 
-### 1. CAPTCHA Protection on ČEZ Distribuce API
+### 1. HDO schedule doesn't display last days correctly
+
+**Status:** ⚠️ Known limitation (CAPTCHA)
+
+**Description:** After 1 day from configuration, the HDO schedule may display last days
+as high tariff (VT). This is caused by ČEZ API limitation – due to CAPTCHA,
+data cannot be automatically updated daily.
+
+**Workaround:** Reconfigure the integration (Settings → Devices & Services → ČEZ HDO →
+Configure), enter a new CAPTCHA code. Current data will be loaded.
+
+### 2. Compatibility with Home Assistant 2026.02+ (v3.1.0)
+
+**Status:** ✅ Resolved in v3.1.1
+
+**Description:** In Home Assistant 2026.02+, the `LovelaceData` structure was changed.
+The object no longer has a `mode` attribute, which caused an error during integration startup:
+`'LovelaceData' object has no attribute 'mode'`
+
+**Resolution:** New storage mode detection using resources collection type check.
+
+**Tracking:** [#62](https://github.com/Cmajda/ha_cez_distribuce/issues/62)
+
+---
+
+### 3. CAPTCHA Protection on ČEZ Distribuce API
 
 **Status:** ✅ Resolved in v3.1.0
 
@@ -23,7 +48,7 @@ and creating automations for notifications.
 
 ---
 
-### 2. set_prices service doesn't distinguish devices
+### 4. set_prices service doesn't distinguish devices
 
 **Status:** ⚠️ Known limitation
 


### PR DESCRIPTION
## Changes

- Fix `'LovelaceData' object has no attribute 'mode'` error in HA 2026.02+
- Replace `lovelace_mode` property with `is_storage_mode` detection
- Bump version to 3.1.1
- Add minimum HA version 2024.7.0
- Update known-issues docs (CS/EN)
- Add RELEASE_NOTES_EN.md

**Fixes #62**