### PR TITLE
fix(entity): slugify user-defined entity suffix

### DIFF
--- a/custom_components/cez_hdo/binary_sensor.py
+++ b/custom_components/cez_hdo/binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DATA_COORDINATOR, DOMAIN
-from .const import ean_short, mask_ean, sanitize_signal
+from .const import ean_short, mask_ean, sanitize_signal, sanitize_suffix
 from .coordinator import CezHdoCoordinator, CezHdoData
 
 _LOGGER = logging.getLogger(__name__)
@@ -166,9 +166,12 @@ class CezHdoBinarySensor(CoordinatorEntity[CezHdoCoordinator], BinarySensorEntit
 
         # Build object_id using entity_suffix from config or auto-generate
         base_object_id = meta.get("object_id", f"cez_hdo_{name.lower()}")
-        if entity_suffix:
+        # Slugify the user-defined suffix - it is raw config-flow input and may
+        # contain uppercase letters or other characters invalid in an entity ID.
+        suffix_safe = sanitize_suffix(entity_suffix)
+        if suffix_safe:
             # Use user-defined suffix
-            self._object_id = f"{base_object_id}_{entity_suffix}"
+            self._object_id = f"{base_object_id}_{suffix_safe}"
         else:
             # Auto-generate suffix from EAN and signal (fallback for YAML config)
             ean4 = ean_short(ean)

--- a/custom_components/cez_hdo/const.py
+++ b/custom_components/cez_hdo/const.py
@@ -1,5 +1,7 @@
 """Constants for ČEZ HDO integration."""
 
+from homeassistant.util import slugify
+
 DOMAIN = "cez_hdo"
 
 # Configuration keys
@@ -58,3 +60,19 @@ def sanitize_signal(signal: str) -> str:
     for char in '|/\\:*?"<>':
         sanitized = sanitized.replace(char, "_")
     return sanitized
+
+
+def sanitize_suffix(suffix: str | None) -> str:
+    """Sanitize the user-defined entity suffix for use in entity IDs.
+
+    The suffix comes straight from free-text user input in the config flow,
+    so it may contain uppercase letters, spaces or diacritics - none of which
+    are valid in an entity ID. Slugify is the same helper Home Assistant uses
+    when it builds entity IDs itself, so the result is exactly what HA would
+    have coerced the value to anyway.
+
+    Example: CEZ -> cez, "Můj dům" -> muj_dum
+    """
+    if not suffix:
+        return ""
+    return slugify(suffix)

--- a/custom_components/cez_hdo/sensor.py
+++ b/custom_components/cez_hdo/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from . import DATA_COORDINATOR, DOMAIN, downloader
-from .const import ean_short, mask_ean, sanitize_signal
+from .const import ean_short, mask_ean, sanitize_signal, sanitize_suffix
 from .coordinator import CezHdoCoordinator, CezHdoData
 
 _LOGGER = logging.getLogger(__name__)
@@ -220,9 +220,12 @@ class CezHdoSensor(CoordinatorEntity[CezHdoCoordinator], SensorEntity):
 
         # Build object_id using entity_suffix from config or auto-generate
         base_object_id = meta.get("object_id", f"cez_hdo_{name.lower()}")
-        if entity_suffix:
+        # Slugify the user-defined suffix - it is raw config-flow input and may
+        # contain uppercase letters or other characters invalid in an entity ID.
+        suffix_safe = sanitize_suffix(entity_suffix)
+        if suffix_safe:
             # Use user-defined suffix
-            self._object_id = f"{base_object_id}_{entity_suffix}"
+            self._object_id = f"{base_object_id}_{suffix_safe}"
         else:
             # Auto-generate suffix from EAN and signal (fallback for YAML config)
             ean4 = ean_short(ean)


### PR DESCRIPTION
Fixes #81

## Problem

`entity_suffix` is free-text user input from the config flow and was interpolated into `object_id` verbatim, so a suffix like `CEZ` produced `sensor.cez_hdo_data_age_days_CEZ`. HA logs a deprecation warning per entity on every startup and reload, and this **stops working in HA 2027.2.0**.

## Change

New `sanitize_suffix()` helper in `const.py`, next to the existing `sanitize_signal()`, wired into both `sensor.py` and `binary_sensor.py`:

```python
suffix_safe = sanitize_suffix(entity_suffix)
if suffix_safe:
    self._object_id = f"{base_object_id}_{suffix_safe}"
else:
    # unchanged auto-generate branch
```

It uses `homeassistant.util.slugify` - the same helper HA uses when building entity IDs itself - rather than hand-rolling character replacement, so diacritics and spaces are handled too (`"Můj dům"` -> `muj_dum`).

## Backwards compatibility

**No entity IDs change and no migration is needed.** HA was already coercing the invalid ID to its slugified form, so the value this PR now sets is what existing installs already have. Verified against a live install (HA 2026.7.4) that had the suffix `CEZ`:

| | value |
|---|---|
| suffix in `entry.data` | `CEZ` |
| entity ID before this PR (HA-coerced) | `sensor.cez_hdo_data_age_days_cez` |
| `slugify("CEZ")` | `cez` |
| entity ID after this PR | `sensor.cez_hdo_data_age_days_cez` |

Note the guard is now on the *slugified* value rather than the raw one, so a suffix that slugifies to nothing falls through to the existing EAN/signal auto-generation branch. (HA's `slugify` returns `"unknown"` rather than `""` for input like `"!!!"`, so in practice that branch is only reached for an empty/whitespace suffix - same as before.)

## Checks

- `python -m py_compile custom_components/cez_hdo/*.py` - passes
- `ruff check` - all checks passed
- `ruff format --check` - already formatted

## Not included

Normalising the suffix at config-flow input time (so `entry.data` stores the clean value) would be reasonable hygiene, but it is not needed to fix the bug and I kept this PR minimal. Happy to add it if you prefer.

Separately, `CezHdoOptionsFlow` does not expose `entity_suffix`, so affected users currently cannot change it without removing and re-adding the integration. Might be worth a follow-up.